### PR TITLE
Add CI 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on: ["push"]
 
 jobs:
-    do_et:
+    ci:
         # same as jetson :p
         runs-on: ubuntu-22.04 
         steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+on: ["push"]
+
+jobs:
+    do_et:
+        # same as jetson :p
+        runs-on: ubuntu-22.04 
+        steps:
+            - uses: actions/checkout@v4
+
+            # grab uv, cargo, and ros 2
+            - uses: astral-sh/setup-uv@v5
+            - uses: moonrepo/setup-rust@v1
+            - uses: ros-tooling/setup-ros@v0.7
+              with:
+                required-ros-distributions: humble
+
+            # grab a python binary
+            - name: Set up Python
+              run: uv python install
+
+            # set up environment
+            - name: Install the project
+              run: |
+                uv sync --all-extras --dev
+                . .venv/bin/activate
+
+            # check python lints
+            - name: Lint and Format (Python)
+              run: |
+                uv tool run ruff check
+                uv tool run ruff format --check
+                
+            # and rust too
+            - name: Lint and Format (Rust)
+              run: |
+                cargo clippy
+                cargo fmt --check
+
+            # build the entire ROS 2 workspace just to ensure things work.
+            #
+            # this'll use colcon
+            - name: Build ROS 2 workspace
+              uses: ros-tooling/action-ros-ci@v0.3
+              with:
+                target-ros2-distro: humble

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 src/**/**.egg-info
 src/**/uv.lock
 **/__pycache__
+**/uv.lock
 
 # rust build stuff
 target/
@@ -17,3 +18,5 @@ target/
 .ropeproject
 .DS_Store
 **/.pdb
+**/.vscode
+**/.zed

--- a/README.md
+++ b/README.md
@@ -27,7 +27,11 @@ To launch Python code, you typically use the `ros2` command. You'll need to sour
 # mine is here:
 source /usr/lib64/ros2-jazzy/setup.bash
 
-# next, compile the scripts using `colcon`
+# next, grab the scripts' dependencies using uv, then hop in its venv
+uv sync
+. ./venv/bin/activate
+
+# compile all ros2 packages using `colcon`
 colcon build --symlink-install
 
 # you'll get an `install/` folder inside the `auto_ros2` repo!
@@ -39,7 +43,7 @@ source install/local_setup.bash
 Great, you're set up to run the code! Fair warning: **each time you open a new terminal, you'll need to `source` those files.**
 
 ```bash
-# in ROS 2, you have to compile the Nodes before ROS 2 can run them.
+# in ROS 2, you have to compile packages before your changes are made.
 #
 # that means using `colcon`, like so:
 colcon build --symlink-install
@@ -48,10 +52,4 @@ colcon build --symlink-install
 ros2 run node_name node_name
 ```
 
-### Rust
-
-Rust is a bit easier. Make sure [it's installed](./CONTRIBUTING.md) and type:
-
-```bash
-cargo run
-```
+For info about installing any of those dependencies, including ROS 2, please see the [`CONTRIBUTING.md`](./CONTRIBUTING.md) file.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "autonomous"
+version = "0.2.0"
+requires-python = ">=3.13"
+
+[tool.uv.sources]
+# if one python project depends on another, put it here!
+#
+# for now, though, it's empty. :D
+
+[tool.uv.workspace]
+members = ["src/navigator_node", "src/log_node"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,3 +10,11 @@ requires-python = ">=3.13"
 
 [tool.uv.workspace]
 members = ["src/navigator_node", "src/log_node"]
+
+[dependency-groups]
+dev = [
+    "colcon-cargo>=0.1.3",
+    "colcon-common-extensions>=0.3.0",
+    "colcon-ros-cargo>=0.2.0",
+    "ruff>=0.9.4",
+]

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,17 @@
+# `src/`: The ROS 2 Nodes
+
+This folder contains all of our ROS 2 nodes.
+
+## Adding a New Node
+
+To add a new node, you'll need to pick either Python or Rust for the project. Copy the (TODO: some python template) or (TODO: rust template) folder.
+
+### Rust
+
+- TODO.
+
+### Python
+
+- Add your new package the root `/pyproject.toml` under the `[tool.uv.workspace] members` section.
+- Rename the node's `pyproject.toml` (`src/<new_python_node_name>/pyproject.toml`) to the node's new name.
+- Do the same in the node's `package.xml`.

--- a/src/README.md
+++ b/src/README.md
@@ -1,4 +1,4 @@
-# `src/`: The ROS 2 Nodes
+# `src/` - The ROS 2 Nodes
 
 This folder contains all of our ROS 2 nodes.
 
@@ -8,10 +8,14 @@ To add a new node, you'll need to pick either Python or Rust for the project. Co
 
 ### Rust
 
-- TODO.
+- Add your new package in the root `/Cargo.toml` in the `members` array.
+- Change the name of the `template_node` folder to use the new name.
+- Edit the package `Cargo.toml` with `name = "<new_node_name>"`.
+- Change the name in `package.xml`.
 
 ### Python
 
-- Add your new package the root `/pyproject.toml` under the `[tool.uv.workspace] members` section.
-- Rename the node's `pyproject.toml` (`src/<new_python_node_name>/pyproject.toml`) to the node's new name.
+- Add your new package in the root `/pyproject.toml` under the `[tool.uv.workspace] members` section.
+- Change the node's `pyproject.toml` (`src/<new_python_node_name>/pyproject.toml`) `name` field to the node's new name.
+- In `/src/`, rename the `template_node`, `template_node/template_node`, and `template_node/resources/template_node` folders/files, too.
 - Do the same in the node's `package.xml`.

--- a/src/autonomous_node/CMakeLists.txt
+++ b/src/autonomous_node/CMakeLists.txt
@@ -1,6 +1,0 @@
-cmake_minimum_required(VERSION 3.5)
-project(autonomous_node)
-
-find_package(ament_cmake REQUIRED)
-
-ament_package()

--- a/src/autonomous_node/package.xml
+++ b/src/autonomous_node/package.xml
@@ -11,9 +11,9 @@
 
     <license>TODO</license>
 
-    <buildtool_depend>ament_cmake</buildtool_depend>
+    <buildtool_depend>ament_cargo</buildtool_depend>
 
     <export>
-        <build_type>ament_cmake</build_type>
+        <build_type>ament_cargo</build_type>
     </export>
 </package>

--- a/src/navigator_node/test/test_pep257.py
+++ b/src/navigator_node/test/test_pep257.py
@@ -19,5 +19,5 @@ import pytest
 @pytest.mark.linter
 @pytest.mark.pep257
 def test_pep257():
-    rc = main(argv=['.', 'test'])
-    assert rc == 0, 'Found code style errors / warnings'
+    rc = main(argv=[".", "test"])
+    assert rc == 0, "Found code style errors / warnings"


### PR DESCRIPTION
Lints both the Rust and Python code, uses the `action-ros-ci` Action to run `colcon`, builds all the packages + their nodes, then runs any tests.

We'll probably have to add any simulation stuff we do later on to another workflow, but this seems to work well for now.