### PR TITLE
Add CI :)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on: ["push"]
 
 jobs:
-    do_et:
+    ci:
         # same as jetson :p
         runs-on: ubuntu-22.04 
         steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+on: ["push"]
+
+jobs:
+    do_et:
+        # same as jetson :p
+        runs-on: ubuntu-22.04 
+        steps:
+            - uses: actions/checkout@v4
+
+            # grab uv, cargo, and ros 2
+            - uses: astral-sh/setup-uv@v5
+            - uses: moonrepo/setup-rust@v1
+            - uses: ros-tooling/setup-ros@v0.7
+              with:
+                required-ros-distributions: humble
+
+            # grab a python binary
+            - name: Set up Python
+              run: uv python install
+
+            # set up environment
+            - name: Install the project
+              run: |
+                uv sync --all-extras --dev
+                . .venv/bin/activate
+
+            # check python lints
+            - name: Lint and Format (Python)
+              run: |
+                uv tool run ruff check
+                uv tool run ruff format --check
+                
+            # and rust too
+            - name: Lint and Format (Rust)
+              run: |
+                cargo clippy
+                cargo fmt --check
+
+            # build the entire ROS 2 workspace just to ensure things work.
+            #
+            # this'll use colcon
+            - name: Build ROS 2 workspace
+              uses: ros-tooling/action-ros-ci@v0.3
+              with:
+                target-ros2-distro: humble

--- a/src/navigator_node/test/test_pep257.py
+++ b/src/navigator_node/test/test_pep257.py
@@ -19,5 +19,5 @@ import pytest
 @pytest.mark.linter
 @pytest.mark.pep257
 def test_pep257():
-    rc = main(argv=['.', 'test'])
-    assert rc == 0, 'Found code style errors / warnings'
+    rc = main(argv=[".", "test"])
+    assert rc == 0, "Found code style errors / warnings"


### PR DESCRIPTION
Lints both the Rust and Python code, uses the `action-ros-ci` Action to run `colcon`, builds all the packages + their nodes, then runs any tests.

We'll probably have to add any simulation stuff we do later on to another workflow, but this seems to work well for now.