### PR TITLE
Scaffolding for ros2-client To safe_drive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,12 +82,12 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "6680de5231bd6ee4c6191b8a1325daa282b415391ec9d3a37bd34f2060dc73fa"
 dependencies = [
  "anstyle",
- "once_cell",
+ "once_cell_polyfill",
  "windows-sys 0.59.0",
 ]
 
@@ -123,9 +123,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line",
  "cfg-if 1.0.0",
@@ -150,9 +150,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "bstr"
@@ -173,9 +173,9 @@ checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "bytemuck"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
+checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
 
 [[package]]
 name = "byteorder"
@@ -200,9 +200,9 @@ checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
 
 [[package]]
 name = "cc"
-version = "1.2.19"
+version = "1.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3a13707ac958681c13b39b458c073d0d9bc8a22cb1b2f4c8e55eb72c13f362"
+checksum = "16595d3be041c03b09d08d0858631facccee9221e579704070e6e9e4915d3bc7"
 dependencies = [
  "shlex",
 ]
@@ -256,9 +256,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -271,18 +271,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.37"
+version = "4.5.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
+checksum = "ed93b9805f8ba930df42c2590f05453d5ec36cbb85d018868a5b24d31f6ac000"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.37"
+version = "4.5.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
+checksum = "379026ff283facf611b0ea629334361c4211d1b12ee01024eec1591133b04120"
 dependencies = [
  "anstream",
  "anstyle",
@@ -322,6 +322,15 @@ name = "crc16"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "338089f42c427b86394a5ee60ff321da23a5c89c9d89514c829687b26359fcff"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "crossbeam-utils"
@@ -383,7 +392,7 @@ checksum = "fc4caf64a58d7a6d65ab00639b046ff54399a39f5f2554728895ace4b297cd79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -394,9 +403,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
+checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -432,7 +441,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 [[package]]
 name = "feedback"
 version = "0.2.4"
-source = "git+https://github.com/onkoe/feedback#e2ade920b798ed6c358d3c1d2c9784a7bd61b6e5"
+source = "git+https://github.com/onkoe/feedback?rev=e2ade92#e2ade920b798ed6c358d3c1d2c9784a7bd61b6e5"
 dependencies = [
  "bytemuck",
  "futures-lite",
@@ -532,7 +541,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -567,9 +576,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -578,9 +587,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -602,9 +611,9 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 
 [[package]]
 name = "humantime"
@@ -772,13 +781,13 @@ checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "local-ip-address"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3669cf5561f8d27e8fc84cc15e58350e70f557d4d65f70e3154e54cd2f8e1782"
+checksum = "656b3b27f8893f7bbf9485148ff9a65f019e3f33bd5cdc87c83cab16b3fd9ec8"
 dependencies = [
  "libc",
  "neli",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "windows-sys 0.59.0",
 ]
 
@@ -1016,7 +1025,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1042,6 +1051,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "ordered-float"
@@ -1094,6 +1109,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pin-project"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1122,7 +1157,7 @@ checksum = "765ef270eab02ca26aeb2aedf9ac4c3d759f70b20ff7351aea10d21f162e0884"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1170,7 +1205,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1296,7 +1331,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -1305,16 +1340,16 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
+checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -1434,11 +1469,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1447,15 +1482,33 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "safe_drive"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aadaa3f465516e10b7ae6213e4ac790673257a3f2b55d2ff77e69e9962d0d94d"
+dependencies = [
+ "crossbeam-channel",
+ "futures",
+ "libc",
+ "num-derive",
+ "num-traits",
+ "once_cell",
+ "parking_lot",
+ "pin-project",
+ "regex",
+ "signal-hook",
+]
 
 [[package]]
 name = "sbp"
@@ -1482,6 +1535,7 @@ dependencies = [
  "camino",
  "feedback",
  "ros2-client",
+ "safe_drive",
  "serde",
  "soro_gps",
  "tokio",
@@ -1518,7 +1572,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1541,7 +1595,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1573,6 +1627,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1599,9 +1672,9 @@ dependencies = [
 
 [[package]]
 name = "socketpair"
-version = "0.19.6"
+version = "0.19.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e080a99f2e77eec97a09840a24ff0fcf1f277cf01993c39d91b25043b1767681"
+checksum = "20296a054f6fb573c1f73e49b0e3afd1efcc643548928fc9c21144f5ecf4f7e3"
 dependencies = [
  "io-extras",
  "io-lifetimes",
@@ -1612,8 +1685,8 @@ dependencies = [
 
 [[package]]
 name = "soro_gps"
-version = "1.0.2"
-source = "git+https://github.com/Sooner-Rover-Team/gps-rs#a0f29705ac91379926117bbfc7f5eeaea3154ced"
+version = "1.1.0"
+source = "git+https://github.com/Sooner-Rover-Team/gps-rs#e8060208da74aab1b42a7464b827ce0cc37a18bf"
 dependencies = [
  "pisserror",
  "sbp",
@@ -1641,7 +1714,7 @@ checksum = "658f2ca5276b92c3dfd65fa88316b4e032ace68f88d7570b43967784c0bac5ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1669,9 +1742,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1704,7 +1777,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1715,7 +1788,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1740,9 +1813,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.2"
+version = "1.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
+checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
 dependencies = [
  "backtrace",
  "libc",
@@ -1762,7 +1835,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1778,9 +1851,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9590b93e6fcc1739458317cccd391ad3955e2bde8913edf6f95f9e65a8f034"
+checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1808,7 +1881,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1888,25 +1961,27 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
+ "js-sys",
  "rand 0.9.1",
  "serde",
  "uuid-macro-internal",
+ "wasm-bindgen",
 ]
 
 [[package]]
 name = "uuid-macro-internal"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72dcd78c4f979627a754f5522cea6e6a25e55139056535fe6e69c506cd64a862"
+checksum = "26b682e8c381995ea03130e381928e0e005b7c9eb483c6c8682f50e07b33c2b7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1952,7 +2027,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "wasm-bindgen-shared",
 ]
 
@@ -1974,7 +2049,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2044,9 +2119,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
-version = "0.61.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
@@ -2063,7 +2138,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2074,7 +2149,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2085,18 +2160,18 @@ checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
 name = "windows-result"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
  "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link",
 ]
@@ -2255,7 +2330,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -2270,21 +2345,20 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
-

--- a/src/sensors/Cargo.toml
+++ b/src/sensors/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/main.rs"
 camino = "1.1"
 ros2-client = "0.8.0"
 serde = "1.0.217"
-feedback = { git = "https://github.com/onkoe/feedback", version = "0.2.4", default-features = false }
+feedback = { git = "https://github.com/onkoe/feedback", rev = "e2ade92", version = "0.2.4", default-features = false }
 soro_gps = { git = "https://github.com/Sooner-Rover-Team/gps-rs", version = "1.0.2", default-features = false }
 tokio = { version = "1.42.0", features = [
     "macros",
@@ -26,3 +26,4 @@ tokio-stream = "0.1.17"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 uuid = { version = "1.13.1", features = ["v4"] }
+safe_drive = { version = "0.4.3", features = ["humble"] }

--- a/src/sensors/package.xml
+++ b/src/sensors/package.xml
@@ -4,9 +4,7 @@
     <name>sensors</name>
     <version>0.1.0</version>
     <description>Grabs sensor data from the Rover.</description>
-
     <maintainer email="contact@barretts.club">Barrett Ray</maintainer>
-
     <license>TODO</license>
 
     <export>

--- a/src/sensors/src/logic.rs
+++ b/src/sensors/src/logic.rs
@@ -1,62 +1,48 @@
 //! Logic is encapsulated here to avoid clutter in the `main` module.
 
-use ros2_client::{
-    log::LogLevel, rosout, Context, MessageTypeName, Name, Node, NodeName, NodeOptions,
+use std::{sync::Arc, time::Duration};
+
+use safe_drive::{
+    logger::Logger,
+    msg::common_interfaces::sensor_msgs::msg::{Imu, NavSatFix},
+    node::Node,
+    pr_debug,
+    qos::{
+        policy::{DurabilityPolicy, HistoryPolicy, ReliabilityPolicy},
+        Profile,
+    },
+    topic::publisher::Publisher,
 };
 use soro_gps::Gps;
 
-use crate::{
-    msg::sensors::{GpsMessage, ImuMessage},
-    SensorSetup,
-};
+use crate::SensorSetup;
 
-/// Creates the `sensors_node`.
-#[tracing::instrument(skip(ctx))]
-pub fn create_node(ctx: &Context) -> Node {
-    ctx.new_node(
-        NodeName::new("/rustdds", "sensors_node").unwrap(),
-        NodeOptions::new().enable_rosout(true),
-    )
-    .expect("node creation")
-}
-
+// ros2-client to safe_drive NOTICE
+// My attempt at recreating the DEFAULT_SUBSCRIPTION_QOS from ros2-client. Might be good to change...
+//
 /// Creates the set of QOS policies used to power the networking functionality.
 ///
 /// Note that these are a little arbitrary. It might be nice to define them in
 /// a shared crate library or at least find the 'best' values on the Rover
 /// for competition.
 #[tracing::instrument]
-pub fn qos() -> ros2_client::ros2::QosPolicies {
-    ros2_client::DEFAULT_SUBSCRIPTION_QOS.clone()
-}
-
-/// Starts 'spinning' the given `Node`.
-///
-/// This spawns a background task that runs until the Node is turned off.
-/// Without the spinner running, the Node is functionally useless. The same
-/// is true for Nodes in Python.
-#[tracing::instrument(skip(node))]
-pub fn spin(node: &mut Node) {
-    // try making the spinner task
-    let spinner = node
-        .spinner()
-        .inspect_err(|e| tracing::error!("failed to make spinner! see: {e}"))
-        .unwrap();
-
-    tokio::task::spawn(async move {
-        // note: this will 'spin' until the Node is dropped (meaning the
-        // program is shutting down)
-        let _ = spinner
-            .spin()
-            .await
-            .inspect_err(|e| tracing::warn!("failed to spin node! see: {e}"));
-    });
+pub fn qos() -> Profile {
+    Profile {
+        history: HistoryPolicy::KeepLast,
+        depth: 1,
+        reliability: ReliabilityPolicy::BestEffort,
+        durability: DurabilityPolicy::Volatile,
+        deadline: Duration::MAX,
+        lifespan: Duration::MAX,
+        ..Default::default()
+    }
 }
 
 /// Starts all tasks that over all sensor data and to publish to the correct topics.
 pub async fn spawn_sensor_publisher_tasks(
     sensor_setup: impl AsRef<SensorSetup>,
-    mut sensors_node: Node,
+    sensors_node: Arc<Node>,
+    logger: Arc<Logger>,
 ) {
     let sensor_setup = sensor_setup.as_ref();
     // TODO: create mono cam, depth cam, battery, imu publishers
@@ -68,18 +54,9 @@ pub async fn spawn_sensor_publisher_tasks(
 
     // spawn gps task
     {
-        let gps_topic = sensors_node
-            .create_topic(
-                &Name::new("/sensors", "gps").expect("valid topic name"),
-                MessageTypeName::new("custom_interfaces", "GpsMessage"),
-                &qos(),
-            )
+        let gps_pubisher: Publisher<NavSatFix> = sensors_node
+            .create_publisher("gps", Some(qos()))
             .expect("create gps topic");
-
-        // make a gps publisher
-        let gps_pub = sensors_node
-            .create_publisher::<GpsMessage>(&gps_topic, Some(qos()))
-            .expect("create gps publisher");
 
         // connect to gps
         //
@@ -89,27 +66,19 @@ pub async fn spawn_sensor_publisher_tasks(
             .await
             .expect("gps creation");
 
-        tokio::task::spawn(sensor_tasks::gps_task(gps, gps_pub));
-        rosout!(sensors_node, LogLevel::Debug, "made gps task!");
+        tokio::task::spawn(sensor_tasks::gps_task(gps, gps_pubisher));
+        pr_debug!(logger, "Made GPS task!");
     }
 
     // spawn imu task
     {
         // imu_task
-        let imu_topic = sensors_node
-            .create_topic(
-                &Name::new("/sensors", "imu").expect("valid topic name"),
-                MessageTypeName::new("custom_interfaces", "ImuMessage"),
-                &qos(),
-            )
+        let imu_publisher: Publisher<Imu> = sensors_node
+            .create_publisher("imu", Some(qos()))
             .expect("create imu topic");
 
-        let imu_pub = sensors_node
-            .create_publisher::<ImuMessage>(&imu_topic, Some(qos()))
-            .expect("create imu publisher");
-
-        tokio::task::spawn(sensor_tasks::imu_task(imu_pub));
-        rosout!(sensors_node, LogLevel::Debug, "made gps task!");
+        tokio::task::spawn(sensor_tasks::imu_task(imu_publisher));
+        pr_debug!(logger, "Made IMU task");
     }
 }
 
@@ -118,20 +87,20 @@ mod sensor_tasks {
     use std::{net::Ipv4Addr, time::Duration};
 
     use feedback::parse::Message;
-    use ros2_client::Publisher;
+    use safe_drive::{
+        msg::common_interfaces::{
+            geometry_msgs::msg::Vector3,
+            sensor_msgs::msg::{Imu, NavSatFix},
+        },
+        topic::publisher::Publisher,
+    };
     use soro_gps::Gps;
     use tokio::net::UdpSocket;
 
-    use crate::{
-        msg::{
-            builtins::Vector3,
-            sensors::{GpsMessage, ImuMessage},
-        },
-        SensorSetup,
-    };
+    use crate::SensorSetup;
 
     /// Publishes `GpsMessage`s when the GPS provides an update.
-    pub async fn gps_task(mut gps: Gps, gps_pub: Publisher<GpsMessage>) {
+    pub async fn gps_task(mut gps: Gps, gps_pub: Publisher<NavSatFix>) {
         // every 1/20th of a second, check for any updates.
         //
         // if the data is different, we'll publish it in a message.
@@ -148,20 +117,28 @@ mod sensor_tasks {
                 }
             };
 
-            // make a ros 2 msg from that info
-            let gps_message = GpsMessage {
-                lat: gps_data.coord.lat,
-                lon: gps_data.coord.lon,
-                height: gps_data.height.0,
-                error_mm: 0.0,
-                time_of_week: gps_data.tow.0,
-            };
-            tracing::debug!("Publishing GPS message: {gps_message:?}");
+            // // make a ros 2 msg from that info
+            // let gps_message = GpsMessage {
+            //     lat: gps_data.coord.lat,
+            //     lon: gps_data.coord.lon,
+            //     height: gps_data.height.0,
+            //     error_mm: 0.0,
+            //     time_of_week: gps_data.tow.0,
+            // };
+
+            // DOUBLE CHECK
+            let mut nav_sat_fix = NavSatFix::new().expect("init NavSatFix message");
+            nav_sat_fix.latitude = gps_data.coord.lat;
+            nav_sat_fix.longitude = gps_data.coord.lon;
+            nav_sat_fix.altitude = gps_data.height.0;
+            // include error_mm?
+            // include tow?
+
+            tracing::debug!("Publishing GPS message: {nav_sat_fix:?}");
 
             // if we got all the values, publish them!
             _ = gps_pub
-                .async_publish(gps_message)
-                .await
+                .send(&nav_sat_fix)
                 .inspect_err(|e| tracing::warn!("failed to write GPS message! err: {e}"))
                 .inspect(|()| tracing::trace!("Published GPS message successfully!"));
 
@@ -180,7 +157,7 @@ mod sensor_tasks {
         }
     }
 
-    pub async fn imu_task(imu_pub: Publisher<ImuMessage>) {
+    pub async fn imu_task(imu_pub: Publisher<Imu>) {
         let sock: UdpSocket =
             UdpSocket::bind((Ipv4Addr::UNSPECIFIED, SensorSetup::default().imu_port))
                 .await
@@ -210,30 +187,47 @@ mod sensor_tasks {
                 continue;
             };
 
-            // make a ros 2 message from that parsed info
-            let msg = ImuMessage {
-                accel: Vector3 {
-                    x: imu_raw.accel_x,
-                    y: imu_raw.accel_y,
-                    z: imu_raw.accel_z,
-                },
-                gyro: Vector3 {
-                    x: imu_raw.gyro_x,
-                    y: imu_raw.gyro_y,
-                    z: imu_raw.gyro_z,
-                },
-                compass: Vector3 {
-                    x: imu_raw.compass_x,
-                    y: imu_raw.compass_y,
-                    z: imu_raw.compass_z,
-                },
-                temp_c: imu_raw.temp_c,
+            // // make a ros 2 message from that parsed info
+            // let msg = ImuMessage {
+            //     accel: Vector3 {
+            //         x: imu_raw.accel_x,
+            //         y: imu_raw.accel_y,
+            //         z: imu_raw.accel_z,
+            //     },
+            //     gyro: Vector3 {
+            //         x: imu_raw.gyro_x,
+            //         y: imu_raw.gyro_y,
+            //         z: imu_raw.gyro_z,
+            //     },
+            //     compass: Vector3 {
+            //         x: imu_raw.compass_x,
+            //         y: imu_raw.compass_y,
+            //         z: imu_raw.compass_z,
+            //     },
+            //     temp_c: imu_raw.temp_c,
+            // };
+
+            // DOUBLE CHECK
+            let mut imu_msg = Imu::new().expect("init Imu message");
+            imu_msg.linear_acceleration = Vector3 {
+                x: imu_raw.accel_x,
+                y: imu_raw.accel_y,
+                z: imu_raw.accel_z,
             };
+
+            // Convert imu_raw.gyro_* Vector3 to Quaternion?
+            // img_msg.orientation = Quaternion {
+            //     x: todo!(),
+            //     y: todo!(),
+            //     z: todo!(),
+            //     w: todo!(),
+            // };
+
+            // Complete assignment of fields
 
             // publish it
             _ = imu_pub
-                .async_publish(msg)
-                .await
+                .send(&imu_msg)
                 .inspect_err(|e| tracing::error!("failed to publish imu msg. err: {e}"));
         }
     }


### PR DESCRIPTION
Alright, so this is meant to be some sort of progress (or "scaffolding") for #59. I would, however, **not directly merge** from this PR as some stuff had to be changed around due to breaking changes in feedback. Also, I did not get to test this in the sim as my compilations of the full project kept failing 😭. So, to document what's been done:

## sensors
For the most part, the main publisher logic and other ROS things have been moved to safe_drive. However, the message types for NavSatFix and Imu did not align perfectly as they had different field types or fields that were just missing.

## lights
I tried working on this; however, I could not get the custom ROS types (from custom_interfaces) to work. This took the bulk of my time 😭😭and I did look at the documentation for this. For me, the main issue appeared to be that when building with colcon, the Rust crates were trying to compile way before the build process to generate the necessary Rust files could take place. And so there were many missing Cargo.toml errors for when referencing custom_interfaces from the lights node. I did try running the example from safe_drive and it did work. I tried copying it, but I still couldn't get the custom_interfaces to work. So, it might be something to do with the way the build configuration is set up, I'm not sure. 😭All done from the docker container too.