### PR TITLE
Set ROS_DISTRO in SOURCE_SCRIPT.**sh

### DIFF
--- a/SOURCE_SCRIPT.bash
+++ b/SOURCE_SCRIPT.bash
@@ -13,6 +13,11 @@ echo "Sourcing ROS 2 environment files..."
 echo "Done!"
 echo
 
+echo "Setting \`ROS_DISTRO\` environment variable as required by \`safe_drive\`..."
+export ROS_DISTRO=humble
+echo "Done!"
+echo
+
 echo "Setting Nav2-compatible ROS middleware implementation..."
 export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
 echo "Done!"

--- a/SOURCE_SCRIPT.fish
+++ b/SOURCE_SCRIPT.fish
@@ -11,6 +11,11 @@ bass source $ROS2_WORKSPACE_LOCATION/install/local_setup.bash || true
 echo "Done!"
 echo
 
+echo "Setting \`ROS_DISTRO\` environment variable as required by \`safe_drive\`..."
+export ROS_DISTRO=humble
+echo "Done!"
+echo
+
 echo "Setting Nav2-compatible ROS middleware implementation..."
 export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
 echo "Done!"


### PR DESCRIPTION
I guess `safe_drive` wants this, but I've never experienced this error before...

Oh well!

For future Googlers, here's the error we were getting:

```console
error[E0560]: struct `rcl::humble::rcl_subscription_options_s` has no field named `disable_loaned_message`
   --> /home/remi/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/safe_drive-0.4.3/src/topic/subscriber.rs:509:13
    |
509 |             disable_loaned_message: false,
    |             ^^^^^^^^^^^^^^^^^^^^^^ `rcl::humble::rcl_subscription_options_s` does not have this field
    |
    = note: all struct fields are already assigned

error[E0609]: no field `disable_loaned_message` on type `rcl::humble::rcl_subscription_options_s`
   --> /home/remi/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/safe_drive-0.4.3/src/topic/subscriber.rs:517:26
    |
517 |             self.options.disable_loaned_message = true;
    |                          ^^^^^^^^^^^^^^^^^^^^^^ unknown field
    |
    = note: available fields are: `qos`, `allocator`, `rmw_subscription_options`

    Building [======================>  ] 249/260: safe_drive
Some errors have detailed explanations: E0252, E0308, E0428, E0560, E0609, E0659.
For more information about an error, try `rustc --explain E0252`.
warning: safe_drive@0.4.3: 'ROS_DISTRO is not set properly. Defaulting to jazzy.'
```

The fix was simple: use `export ROS_DISTRO=humble` before building.